### PR TITLE
Add priority and status columns feature

### DIFF
--- a/docs-web/src/main/webapp/src/locale/en.json
+++ b/docs-web/src/main/webapp/src/locale/en.json
@@ -66,6 +66,7 @@
     "shared": "Shared",
     "current_step_name": "Current step",
     "title": "Title",
+    "status": "Status",
     "description": "Description",
     "contributors": "Contributors",
     "language": "Language",

--- a/docs-web/src/main/webapp/src/locale/en.json
+++ b/docs-web/src/main/webapp/src/locale/en.json
@@ -181,7 +181,7 @@
       "footer_sismics": "Crafted with <span class=\"fas fa-heart\"></span> by <a href=\"https://www.sismics.com\" target=\"_blank\">Sismics</a>",
       "api_documentation": "API Documentation",
       "feedback": "Give us a feedback",
-      "workflow_document_list": "Documents assigned to you",
+      "workflow_document_list": "Dashboard",
       "select_all": "Select all",
       "select_none": "Select none"
     },

--- a/docs-web/src/main/webapp/src/partial/docs/document.default.html
+++ b/docs-web/src/main/webapp/src/partial/docs/document.default.html
@@ -76,6 +76,7 @@
         <thead>
         <tr>
           <th class="col-xs-6">{{ 'document.title' | translate }}</th>
+          <th class="col-xs-6">{{ 'document.status' | translate }}</th>
           <th class="col-xs-3">{{ 'document.current_step_name' | translate }}</th>
           <th class="col-xs-3">{{ 'document.creation_date' | translate }}</th>
         </tr>

--- a/docs-web/src/main/webapp/src/partial/docs/document.default.html
+++ b/docs-web/src/main/webapp/src/partial/docs/document.default.html
@@ -1,6 +1,7 @@
 <div class="well well-3d" style="background-color: #f6f9fc" id="quick-upload-zone">
   <div class="pull-right" ng-show="files.length > 0">
-    <a href class="btn btn-default" ng-init="selectAll = true" ng-click="changeChecked(selectAll); selectAll = !selectAll">
+    <a href class="btn btn-default" ng-init="selectAll = true"
+      ng-click="changeChecked(selectAll); selectAll = !selectAll">
       <span class="far" ng-class="{ 'fa-check-square': selectAll, 'fa-square': !selectAll }"></span>
       {{ selectAll ? 'document.default.select_all' : 'document.default.select_none' | translate }}
     </a>
@@ -9,19 +10,18 @@
     {{ 'document.default.quick_upload' | translate }}
   </h3>
 
-  <div class="row upload-zone"
-       ngf-drop="fileDropped($files)"
-       ngf-drag-over-class="'bg-success'"
-       ngf-multiple="true"
-       ngf-allow-dir="false">
+  <div class="row upload-zone" ngf-drop="fileDropped($files)" ngf-drag-over-class="'bg-success'" ngf-multiple="true"
+    ngf-allow-dir="false">
     <div class="col-xs-6 col-sm-4 col-md-3 col-lg-2 text-center" ng-repeat="file in files">
       <div class="thumbnail" ng-class="{ 'thumbnail-checked': file.checked }" ng-if="file.id">
         <a class="file-thumbnail" ng-click="openFile(file)">
-          <img ng-src="../api/file/{{ file.id }}/data?size=thumb" uib-tooltip="{{ file.mimetype }} | {{ file.size | filesize }}" tooltip-placement="top" />
+          <img ng-src="../api/file/{{ file.id }}/data?size=thumb"
+            uib-tooltip="{{ file.mimetype }} | {{ file.size | filesize }}" tooltip-placement="top" />
         </a>
         <div class="file-info">
           <div class="v-align">
-            <button class="btn btn-danger" ng-click="deleteFile($event, file)"><span class="fas fa-trash"></span></button>
+            <button class="btn btn-danger" ng-click="deleteFile($event, file)"><span
+                class="fas fa-trash"></span></button>
           </div>
           <div class="v-align file-name" ng-if="file.name">{{ file.name }}</div>
           <div class="v-align">
@@ -47,18 +47,12 @@
   </div>
 
   <p class="text-center">
-    <button ng-show="checkedFiles().length > 0"
-            class="btn btn-primary"
-            ng-click="addDocument()">
+    <button ng-show="checkedFiles().length > 0" class="btn btn-primary" ng-click="addDocument()">
       <span class="fas fa-plus"></span> {{ 'document.default.add_new_document' | translate }}
     </button>
 
-    <button ng-show="checkedFiles().length == 0"
-            class="btn btn-default"
-            ngf-select
-            ngf-change="fileDropped($files, $event)"
-            input-file-multiple="multiple"
-            ngf-multiple="true">
+    <button ng-show="checkedFiles().length == 0" class="btn btn-default" ngf-select
+      ngf-change="fileDropped($files, $event)" input-file-multiple="multiple" ngf-multiple="true">
       {{ 'document.default.add_files' | translate }}
     </button>
   </p>
@@ -74,28 +68,31 @@
 
       <table class="row table table-hover table-documents">
         <thead>
-        <tr>
-          <th class="col-xs-6">{{ 'document.title' | translate }}</th>
-          <th class="col-xs-6">{{ 'document.status' | translate }}</th>
-          <th class="col-xs-3">{{ 'document.current_step_name' | translate }}</th>
-          <th class="col-xs-3">{{ 'document.creation_date' | translate }}</th>
-        </tr>
+          <tr>
+            <th class="col-xs-6">{{ 'document.title' | translate }}</th>
+            <th class="col-xs-6">{{ 'document.current_step_priority' | translate }}</th>
+            <th class="col-xs-6">{{ 'document.current_step_status' | translate }}</th>
+            <th class="col-xs-3">{{ 'document.current_step_name' | translate }}</th>
+            <th class="col-xs-3">{{ 'document.creation_date' | translate }}</th>
+          </tr>
         </thead>
         <tbody>
-        <tr ng-click="viewDocument(document.id)" ng-repeat="document in documentsWorkflow">
-          <td>
-            {{ document.title }} ({{ document.file_count }})
-            <div class="tags small">
-              <span class="label label-info" ng-repeat="tag in document.tags" ng-style="{ 'background': tag.color }">
-                {{ tag.name }}
-              </span>
-            </div>
-          </td>
-          <td>{{ document.current_step_name }}</td>
-          <td>
-            <div class="text-muted small">{{ document.create_date | timeAgo: dateFormat }}</div>
-          </td>
-        </tr>
+          <tr ng-click="viewDocument(document.id)" ng-repeat="document in documentsWorkflow">
+            <td>
+              {{ document.title }} ({{ document.file_count }})
+              <div class="tags small">
+                <span class="label label-info" ng-repeat="tag in document.tags" ng-style="{ 'background': tag.color }">
+                  {{ tag.name }}
+                </span>
+              </div>
+            </td>
+            <td>{{ document.current_step_priority }}</td>
+            <td>{{ document.current_step_status }}</td>
+            <td>{{ document.current_step_name }}</td>
+            <td>
+              <div class="text-muted small">{{ document.create_date | timeAgo: dateFormat }}</div>
+            </td>
+          </tr>
         </tbody>
       </table>
     </div>
@@ -106,7 +103,7 @@
   <span class="fas fa-circle-notch fa-spin"></span>
 </div>
 
-<div class="well well-3d"  ng-show="logs.length > 0">
+<div class="well well-3d" ng-show="logs.length > 0">
   <h3 class="well-3d-header text-muted">
     {{ 'document.default.latest_activity' | translate }}
   </h3>

--- a/docs-web/src/main/webapp/src/partial/docs/document.view.workflow.html
+++ b/docs-web/src/main/webapp/src/partial/docs/document.view.workflow.html
@@ -47,6 +47,9 @@
     <th>Type</th>
     <th>Name</th>
     <th>For</th>
+    <th>Priority</th>
+    <th>Status</th>
+    <th>Modified Date</th>
     <th>Validation</th>
   </tr>
   </thead>

--- a/docs-web/src/main/webapp/src/partial/docs/document.view.workflow.html
+++ b/docs-web/src/main/webapp/src/partial/docs/document.view.workflow.html
@@ -66,6 +66,18 @@
     <td>
       <acl data="step.target"></acl>
     </td>
+
+    <!--adding column description for Priority--> 
+    <td>
+      <td>{{ step.name }}</td>
+    </td>
+    <!--adding column description for status-->
+    <td>
+      <td>{{ step.name }}</td>
+    </td>
+    <!--end changes-->
+
+
     <td>
       <span ng-show="step.end_date">
           {{ 'workflow_transition.' + step.transition | translate }}
@@ -77,6 +89,8 @@
         </span>
       </span>
     </td>
+    
+
   </tr>
   </tbody>
 </table>

--- a/docs-web/src/main/webapp/src/partial/docs/document.view.workflow.html
+++ b/docs-web/src/main/webapp/src/partial/docs/document.view.workflow.html
@@ -10,7 +10,8 @@
   <strong translate="document.view.workflow.no_workflow"></strong>
 </p>
 
-<form name="startWorkflowForm" class="form-horizontal" novalidate ng-show="!document.route_step && routemodels.length > 0">
+<form name="startWorkflowForm" class="form-horizontal" novalidate
+  ng-show="!document.route_step && routemodels.length > 0">
   <div class="form-group" ng-class="{ 'has-error': !startWorkflowForm.routemodel.$valid && startWorkflowForm.$dirty }">
     <label for="inputRouteModel" class="col-sm-3">
       {{ 'document.view.workflow.workflow_start_label' | translate }}
@@ -24,15 +25,14 @@
       </select>
     </div>
     <div class="col-sm-3">
-      <span class="help-block" ng-show="startWorkflowForm.routemodel.$error.required && startWorkflowForm.$dirty">{{ 'validation.required' | translate }}</span>
+      <span class="help-block" ng-show="startWorkflowForm.routemodel.$error.required && startWorkflowForm.$dirty">{{
+        'validation.required' | translate }}</span>
     </div>
   </div>
 
   <div class="form-group">
     <div class="col-sm-offset-3 col-sm-9">
-      <button type="submit" class="btn btn-primary"
-              ng-disabled="!startWorkflowForm.$valid"
-              ng-click="startWorkflow()">
+      <button type="submit" class="btn btn-primary" ng-disabled="!startWorkflowForm.$valid" ng-click="startWorkflow()">
         {{ 'document.view.workflow.start_workflow_submit' | translate }}
       </button>
     </div>
@@ -41,56 +41,56 @@
 
 <table class="table" ng-repeat="route in routes">
   <caption translate="document.view.workflow.full_name"
-           translate-values="{ name: route.name, create_date: route.create_date }"></caption>
+    translate-values="{ name: route.name, create_date: route.create_date }"></caption>
   <thead>
-  <tr>
-    <th>Type</th>
-    <th>Name</th>
-    <th>For</th>
-    <th>Priority</th>
-    <th>Status</th>
-    <th>Validation</th>
-  </tr>
+    <tr>
+      <th>Type</th>
+      <th>Name</th>
+      <th>For</th>
+      <th>Priority</th>
+      <th>Status</th>
+      <th>Validation</th>
+    </tr>
   </thead>
   <tbody>
-  <tr ng-repeat="step in route.steps" ng-class="{
+    <tr ng-repeat="step in route.steps" ng-class="{
           'bg-success': step.transition == 'VALIDATED' || step.transition == 'APPROVED',
           'bg-danger': step.transition == 'REJECTED'
       }">
-    <td>
-      <span class="fas fa-exchange-alt" ng-if="step.type == 'APPROVE'"></span>
-      <span class="fas fa-check-circle" ng-if="step.type == 'VALIDATE'"></span>
-      {{ 'workflow_type.' + step.type | translate }}
-    </td>
-    <td>{{ step.name }}</td>
-    <td>
-      <acl data="step.target"></acl>
-    </td>
+      <td>
+        <span class="fas fa-exchange-alt" ng-if="step.type == 'APPROVE'"></span>
+        <span class="fas fa-check-circle" ng-if="step.type == 'VALIDATE'"></span>
+        {{ 'workflow_type.' + step.type | translate }}
+      </td>
+      <td>{{ step.name }}</td>
+      <td>
+        <acl data="step.target"></acl>
+      </td>
 
-    <!--adding column description for Priority--> 
-    <td>
-      
-    </td>
-    <!--adding column description for status-->
-    <td>
-      <acl data="step.target"></acl>
-    </td>
-    <!--end changes-->
+      <!--adding column description for Priority-->
+      <td>
+
+      </td>
+      <!--adding column description for status-->
+      <td>
+        <acl data="step.status"></acl>
+      </td>
+      <!--end changes-->
 
 
-    <td>
-      <span ng-show="step.end_date">
+      <td>
+        <span ng-show="step.end_date">
           {{ 'workflow_transition.' + step.transition | translate }}
           {{ step.end_date | timeAgo: dateTimeFormat }}
           by
-        <a href="#/user/{{ step.validator_username }}" class="label label-default">{{ step.validator_username }}</a>
-        <span ng-show="step.comment" class="text-">
-          <br/><em>{{ step.comment }}</em>
+          <a href="#/user/{{ step.validator_username }}" class="label label-default">{{ step.validator_username }}</a>
+          <span ng-show="step.comment" class="text-">
+            <br /><em>{{ step.comment }}</em>
+          </span>
         </span>
-      </span>
-    </td>
-    
+      </td>
 
-  </tr>
+
+    </tr>
   </tbody>
 </table>

--- a/docs-web/src/main/webapp/src/partial/docs/document.view.workflow.html
+++ b/docs-web/src/main/webapp/src/partial/docs/document.view.workflow.html
@@ -49,7 +49,6 @@
     <th>For</th>
     <th>Priority</th>
     <th>Status</th>
-    <th>Modified Date</th>
     <th>Validation</th>
   </tr>
   </thead>

--- a/docs-web/src/main/webapp/src/partial/docs/document.view.workflow.html
+++ b/docs-web/src/main/webapp/src/partial/docs/document.view.workflow.html
@@ -73,7 +73,7 @@
     </td>
     <!--adding column description for status-->
     <td>
-      
+      <acl data="step.target"></acl>
     </td>
     <!--end changes-->
 

--- a/docs-web/src/main/webapp/src/partial/docs/document.view.workflow.html
+++ b/docs-web/src/main/webapp/src/partial/docs/document.view.workflow.html
@@ -69,11 +69,11 @@
 
     <!--adding column description for Priority--> 
     <td>
-      <td>{{ step.name }}</td>
+      
     </td>
     <!--adding column description for status-->
     <td>
-      <td>{{ step.name }}</td>
+      
     </td>
     <!--end changes-->
 

--- a/docs-web/src/main/webapp/src/style/bootstrap.css
+++ b/docs-web/src/main/webapp/src/style/bootstrap.css
@@ -1464,6 +1464,7 @@ th {
 }
 .table > thead > tr > th {
   vertical-align: bottom;
+  text-align: center;
   border-bottom: 2px solid #ddd;
 }
 .table > caption + thead > tr:first-child > th,


### PR DESCRIPTION
I added columns for the Priority and Status in the front end. The displaying changes are made on the `document.view.workflow.html`. The Status column is linked to the back end and middleware functions for retrieving the document's status. The attached object is called `step. status`. 
For the user account, I made changes to the `document.default.html` to display the workflow dashboard. The new line I added is:
`<td>{{ document.current_step_status }}</td>`

Below is the image of the website on the dashboard from admin:
![屏幕截图 2022-10-04 142530](https://user-images.githubusercontent.com/89825717/193897555-04151280-8613-41c1-b3a1-065e3d148fa0.jpg)



 